### PR TITLE
Disabled profile checks for resources of type Parameters

### DIFF
--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -723,14 +723,16 @@ export function testFile( folderName: string, fileName: string, failOnWarning :b
                 }
             });
             test('Check profiles are not present in resource (Implementation Guide Best Practice)', () => {
-                if (json.meta != undefined) {
+                // Disable profile check for Parameters
+                if (json.meta != undefined && json.resourceType !== 'Parameters') {
                     expect(json.meta.profile == undefined).toBeTruthy()
                 }
                 if (json.resourceType === 'Bundle') {
                     let bundle : Bundle = json
                     if (bundle.entry != undefined) {
                         for (let entry of bundle.entry) {
-                            if (entry.resource !== undefined && entry.resource.meta != undefined) {
+                            // Disable profile check for Parameters
+                            if (entry.resource !== undefined && entry.resource.meta != undefined && entry.resource.resourceType !== 'Parameters') {
                                 expect(entry.resource.meta.profile == undefined).toBeTruthy()
                             }
                         }


### PR DESCRIPTION
FHIR R5/R4B of SubscriptionStatus is implemented using the Parameters resource. 

In order to specify the type of resource the meta.profile element is being used. 

This change disables the meta.profile check