### PR TITLE
Added an exception to search Parameter validation.

### DIFF
--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -736,6 +736,7 @@ export function testFile( folderName: string, fileName: string, failOnWarning :b
                 describe('FHIR CapabilityStatement', () => {
                     let capabilityStatement: CapabilityStatement = json
                     if (capabilityStatement != undefined
+                        && (capabilityStatement.kind !== undefined && capabilityStatement.kind !== "instance")
                         && capabilityStatement.rest != undefined
                         && capabilityStatement.rest.length > 0
                         && capabilityStatement.rest[0].resource != undefined) {


### PR DESCRIPTION
CapabilityStatements of kind = instance will be ignored.

This is part of a wider change which moves this code to the FHIR Validator