### PR TITLE
remove @types/axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "start": "ts-node src/configureValidator.ts"
   },
   "devDependencies": {
-    "@types/axios": "^0.14.0",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.6",
     "axios": "^1.6.5",


### PR DESCRIPTION
Fixes the warning at npm Install:

> npm WARN deprecated @types/axios@0.14.0: This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!

