### PR TITLE
Add options to repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ Examples of use within a workflow can be found:
 - https://github.com/NHSDigital/NHSDigital-FHIR-ImplementationGuide/blob/master/.github/workflows/FHIRValidation.yml
 - https://github.com/NHSDigital/NHSDigital-FHIR-Medicines-ImplementationGuide/blob/master/.github/workflows/integration.yml
 
+## Options
+It is possible to set the following options within your FHIR repository:  
+**strict-validation** - *Boolean*: set to true for all warnings to be promoted to errors, false to allow validation to pass with warnings present.  
+**igonore-folders** - *list*: a list of all folders to ignore that do not contain FHIR resources. All folders starting with `.` will be automatically ignored.  
+**igonore-files** - *list*: a list of all json or xml files to be ignored. `fhirpkg.lock.json`, `package.json`, `options.json` will be automatically ignored.  
+**error-if-metaProfile-present** - *Boolean*: [IG best practice](https://build.fhir.org/ig/FHIR/ig-guidance/best-practice.html#examples) states *"Avoid declaring meta.profile in your examples unless there’s an expectation..."*. Setting this attribute to true will cause the validator to error if meta.profile is found within an example.
+The file created will need to be named `options.json` and contain the following:
+```json
+{
+    "strict-validation": false,
+    "ignore-folders": [],
+    "ignore-files": [],
+	"error-if-metaProfile-present": true
+}
+```
+
+
 
 # Simplifier IG Content Checker
 This action checks a Simplifier implementation guide for spelling, http errors and invalid links. More information can be found within the [IGPageContentValidator](https://github.com/NHSDigital/IOPS-FHIR-Test-Scripts/tree/main/IGPageContentValidator) folder.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Examples of use within a workflow can be found:
 
 ## Options
 It is possible to set the following options within your FHIR repository:  
-**strict-validation** - *Boolean*: set to true for all warnings to be promoted to errors, false to allow validation to pass with warnings present.  
-**igonore-folders** - *list*: a list of all folders to ignore that do not contain FHIR resources. All folders starting with `.` will be automatically ignored.  
-**igonore-files** - *list*: a list of all json or xml files to be ignored. `fhirpkg.lock.json`, `package.json`, `options.json` will be automatically ignored.  
-**error-if-metaProfile-present** - *Boolean*: [IG best practice](https://build.fhir.org/ig/FHIR/ig-guidance/best-practice.html#examples) states *"Avoid declaring meta.profile in your examples unless there’s an expectation..."*. Setting this attribute to true will cause the validator to error if meta.profile is found within an example.
+**strict-validation** - *Boolean (default:false)*: set to true for all warnings to be promoted to errors, false to allow validation to pass with warnings present.  
+**igonore-folders** - *list (default:[])*: a list of all folders to ignore that do not contain FHIR resources. All folders starting with `.` will be automatically ignored.  
+**igonore-files** - *list (default:[])*: a list of all json or xml files to be ignored. `fhirpkg.lock.json`, `package.json`, `options.json` will be automatically ignored.  
+**error-if-metaProfile-present** - *Boolean (default:true)*: [IG best practice](https://build.fhir.org/ig/FHIR/ig-guidance/best-practice.html#examples) states *"Avoid declaring meta.profile in your examples unless there’s an expectation..."*. Setting this attribute to true will cause the validator to error if meta.profile is found within an example.
 The file created will need to be named `options.json` and contain the following:
 ```json
 {

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -1,5 +1,5 @@
 import {
-    getFhirClientJSON, isIgnoreFile, isIgnoreFolder, NEW_LINE, testFile
+    getFhirClientJSON, isIgnoreFile, isIgnoreFolder, NEW_LINE, testFile, getStrictValidation
 } from "./common.js";
 import * as fs from "fs";
 import {describe, expect, jest} from "@jest/globals";
@@ -18,10 +18,9 @@ const args = require('minimist')(process.argv.slice(2))
     let source = '../'
     let examples: string
 
-    let failOnWarning = false;
-    if (process.env.FAILONWARNING != undefined && process.env.FAILONWARNING == 'FAILONWARNING') {
-        failOnWarning = true;
-    }
+const failOnWarning = getStrictValidation();
+console.log(`failOnWarning: ${failOnWarning}`);
+
     gitHubSummary += 'Strict validation: ' + failOnWarning + NEW_LINE;
 
     if (args!= undefined) {
@@ -119,13 +118,3 @@ function testFolderContent(dir : string, source: string) {
             }
         })
     }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Options
It is possible to set the following options within your FHIR repository:  
**strict-validation** - *Boolean (default:false)*: set to true for all warnings to be promoted to errors, false to allow validation to pass with warnings present.  
**igonore-folders** - *list (default:[])*: a list of all folders to ignore that do not contain FHIR resources. All folders starting with `.` will be automatically ignored.  
**igonore-files** - *list (default:[])*: a list of all json or xml files to be ignored. `fhirpkg.lock.json`, `package.json`, `options.json` will be automatically ignored.  
**error-if-metaProfile-present** - *Boolean (default:true)*: [IG best practice](https://build.fhir.org/ig/FHIR/ig-guidance/best-practice.html#examples) states *"Avoid declaring meta.profile in your examples unless there’s an expectation..."*. Setting this attribute to true will cause the validator to error if meta.profile is found within an example.
The file created will need to be named `options.json` and contain the following:
```json
{
    "strict-validation": false,
    "ignore-folders": [],
    "ignore-files": [],
	"error-if-metaProfile-present": true
}
```

Tests:
- scrict validation = true + error if meta.Profile present =true
- scrict validation = true + error if meta.Profile present =false
- scrict validation = false + error if meta.Profile present =true
- scrict validation = false + error if meta.Profile present =false
- ignore-files = ["options.json"]
- ignore-folders=["Guides"]
- attributes missing
- options.json missing

all passed as expected.

**minor issue**: console.log prints twice. Think this is down to jest and not code. Not an important issue so leaving as is.