### PR TITLE
Hide http://varnomen.hgvs.org ValueSet errors

### DIFF
--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -265,7 +265,7 @@ function raiseWarning(issue: OperationOutcomeIssue, failOnWarning:boolean): bool
         
         // THESE WARNINGS SHOULD ALWAYS BE SILENTLY IGNORED
 	// Issue with GitHub validator requiring code to be in CodeSystem asset when there is none. No issues with the validator itself. The ValueSet in question is https://terminology.hl7.org/5.5.0/CodeSystem-v3-hgvs.html    
-	if (issue.diganostics.includes('http://varnomen.hgvs.org')) return false
+	if (issue.diagnostics.includes('http://varnomen.hgvs.org')) return false
         //if (issue.diagnostics.includes('Code system https://dmd.nhs.uk/ could not be resolved.')) return false
 	// Issue with hapi giving incorrect error when one code is from the valueset, but another is not. See https://github.com/hapifhir/hapi-fhir/issues/4152
         if (issue.diagnostics.includes('Inappropriate CodeSystem URL') && issue.diagnostics.includes('for ValueSet: http://hl7.org/fhir/ValueSet/all-languages')) {

--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -265,7 +265,7 @@ function raiseWarning(issue: OperationOutcomeIssue, failOnWarning:boolean): bool
         
         // THESE WARNINGS SHOULD ALWAYS BE SILENTLY IGNORED
 	// Issue with GitHub validator requiring code to be in CodeSystem asset when there is none. No issues with the validator itself. The ValueSet in question is https://terminology.hl7.org/5.5.0/CodeSystem-v3-hgvs.html    
-	if (issue.diganostics.includes('http://varnomen.hgvs.org') return false
+	if (issue.diganostics.includes('http://varnomen.hgvs.org')) return false
         //if (issue.diagnostics.includes('Code system https://dmd.nhs.uk/ could not be resolved.')) return false
 	// Issue with hapi giving incorrect error when one code is from the valueset, but another is not. See https://github.com/hapifhir/hapi-fhir/issues/4152
         if (issue.diagnostics.includes('Inappropriate CodeSystem URL') && issue.diagnostics.includes('for ValueSet: http://hl7.org/fhir/ValueSet/all-languages')) {

--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -264,6 +264,8 @@ function raiseWarning(issue: OperationOutcomeIssue, failOnWarning:boolean): bool
         }
         
         // THESE WARNINGS SHOULD ALWAYS BE SILENTLY IGNORED
+	// Issue with GitHub validator requiring code to be in CodeSystem asset when there is none. No issues with the validator itself. The ValueSet in question is https://terminology.hl7.org/5.5.0/CodeSystem-v3-hgvs.html    
+	if (issue.diganostics.includes('http://varnomen.hgvs.org') return false
         //if (issue.diagnostics.includes('Code system https://dmd.nhs.uk/ could not be resolved.')) return false
 	// Issue with hapi giving incorrect error when one code is from the valueset, but another is not. See https://github.com/hapifhir/hapi-fhir/issues/4152
         if (issue.diagnostics.includes('Inappropriate CodeSystem URL') && issue.diagnostics.includes('for ValueSet: http://hl7.org/fhir/ValueSet/all-languages')) {


### PR DESCRIPTION
hide any errors relating to the codesystem `http://varnomen.hgvs.org` within the ValueSet `https://terminology.hl7.org/5.5.0/CodeSystem-v3-hgvs.html` as the ValueSet is empty but binding is `required`. This is only an issue with the github validation and not the validator itself.

This issue can be found in https://github.com/NHSDigital/NHSDigital-FHIR-Genomics-ImplementationGuide/actions/runs/9115457743 
`received: "ERROR None of the codings provided are in the value set 'Human Genome Variation Society (HGVS) Nomenclature' (http://hl7.org/fhir/uv/genomics-reporting/ValueSet/hgvs-vs|3.0.0-ballot), and a coding from this value set is required) (codes = http://varnomen.hgvs.org#NM_001363118.2:c.916G>A) [ Location - Observation.component[3].value.ofType(CodeableConcept)] [ Location - Line[109] Col[6]]
ERROR Validation failed for 'http://varnomen.hgvs.org#NM_001363118.2:c.916G>A' [ Location - Observation.component[3].value.ofType(CodeableConcept).coding[0]] [ Location - Line[110] Col[8]]"`