### PR TITLE
hide system errors related http://human-phenotype-ontology.org

### DIFF
--- a/src/common.js.ts
+++ b/src/common.js.ts
@@ -279,6 +279,9 @@ function raiseWarning(issue: OperationOutcomeIssue, failOnWarning:boolean): bool
         
         //Fragment codesystems can't be checked
         if (issue.diagnostics.includes('Unknown code in fragment CodeSystem')) return false;
+
+	//Hide errors relating to finding codes from system:http://human-phenotype-ontology.org as these are not within the Terminology server
+	if (issue.diagnostics.includes('Validation failed for \'http://human-phenotype-ontology.org')) return false;
     }
 
     // if error not handled above, return error if FailOnWarning is true 


### PR DESCRIPTION
No codes for http://human-phenotype-ontology.org are within the terminology server, nor any CodeSystem thus will give error when trying to validate codes from there. This is to hide these errors

Full error:

> Error: expect(received).toBeFalsy()
>
> Received: "ERROR Validation failed for '[http://human-phenotype-ontology.org#HP:0000105'](https://simplifier.net/resolve?fhirVersion=R4&scope=uk.nhsdigital.r4&canonical=http://human-phenotype-ontology.org#HP:0000105') [ Location - Observation.code.coding[0]] [ Location - Line[9] Col[6]]"
>
>[Observation/Observation-HepaticCysts-Example.json](https://github.com/NHSDigital/NHSDigital-FHIR-Genomics-ImplementationGuide/blob/Feature-IOPS-2542-Structured-Reporting-Duo/Trio-testing-(family-sample)/Observation/Observation-HepaticCysts-Example.json)

Related CodeSystem https://simplifier.net/packages/hl7.terminology.r4/6.1.0/files/2655973/~json