### PR TITLE
Update FHIR server startup validation logic

### DIFF
--- a/.github/workflows/masterfhirvalidation.yml
+++ b/.github/workflows/masterfhirvalidation.yml
@@ -73,17 +73,14 @@ jobs:
               docker logs fhir-server 2>&1 | grep -E "Unable to locate package|Unknown resource name|Error installing IG"
               exit 1
             fi
-
-            if curl -sSf http://localhost:8080/fhir/metadata > /dev/null; then
-              echo "FHIR Validator is up!"
-              sleep 10 #ensure package are installed. This will need to be changed to something better e.g. ensure "fhir is lit" before moving on
+            if docker logs fhir-server 2>&1 | grep -q "A FHIR has been lit on this server"; then
+              echo "FHIR server is fully started and packages are installed!"
               exit 0
             fi
-
-            echo "Waiting for FHIR Validator... attempt $i/60"
-            sleep 10
+            echo "Waiting for FHIR server... attempt $i/120"
+            sleep 5
           done
-          echo "FHIR Validator failed to start in time"
+          echo "FHIR server failed to start in time"
           docker logs fhir-server 2>&1 | tail -50
           exit 1
 


### PR DESCRIPTION
wait for "A FHIR has been lit signal rather than localhost to be up to ensure all packages are installed before moving to the next step