### PR TITLE
Update configure-packages-application-yaml.py

### DIFF
--- a/FHIRValidationAction/scripts/configure-packages-application-yaml.py
+++ b/FHIRValidationAction/scripts/configure-packages-application-yaml.py
@@ -61,7 +61,10 @@ def add_packages_to_application_yaml(source_json, target_yaml=application_yaml):
             'name': package_name,
             'version': version,
             'installMode': 'STORE_AND_INSTALL',
-            'fetchDependencies': True
+            'fetchDependencies': True,
+            'dependencyExcludes': [
+                'hl7.fhir.uv.extensions.r4'
+            ]
         }
         
         if 'implementationguides' not in data['hapi']['fhir']:


### PR DESCRIPTION
Currently hl7.fhir.uv.extensions.r4 < 6.3.0 contains r5 references which breaks hapi 

>-=6.3.0 contains a new extension that currently hapi cannot calculate.

In both cases the following error is brought up

```
HAPI-1286: Error installing IG hl7.terminology.r4#6.3.0: ca.uhn.fhir.rest.server.exceptions.InternalErrorException:   

HAPI-2223: HAPI-1764: theKey must not be null or empty
```

This PR excludes installing hl7.fhir.uv.extensions until a fix is added to hapi