### PR TITLE
Update ignore-list.yaml with specific error URL

### DIFF
--- a/FHIRValidationAction/scripts/ignore-list.yaml
+++ b/FHIRValidationAction/scripts/ignore-list.yaml
@@ -1,5 +1,6 @@
 ignore-list:
-  error: ~
+  error:
+    - http://hl7.eu/fhir/base/StructureDefinition/patient-animal-eu-core #currently blocked by a limitation in hl7-base. https://hl7.eu/fhir/laboratory/StructureDefinition-Patient-animal-eu-lab.html
   warning: 
     - dom-6 #ignore "A resource should have narrative for robust management"
   information: ~


### PR DESCRIPTION
ignore animal-eu error `Unable to resolve the profile reference 'http://hl7.eu/fhir/base/StructureDefinition/patient-animal-eu-core'`
>  The profile PatientAnimalEu, and therefore the use case where the animal is the patient/subject of care, is currently blocked by a limitation in hl7-base.
>
>At the moment, hl7-base allows only PatientEuCore as subject.
>
>This limitation is expected to be resolved in a future version of hl7-base. 

https://hl7.eu/fhir/laboratory/StructureDefinition-Patient-animal-eu-lab.html