### PR TITLE
Stack Trace for terminology.r4

### DIFF
--- a/.github/workflows/masterfhirvalidation.yml
+++ b/.github/workflows/masterfhirvalidation.yml
@@ -53,6 +53,10 @@ jobs:
           pip install ruamel.yaml
           python3 validation/FHIRValidationAction/scripts/configure-packages-application-yaml.py
 
+      - name: Show implementation guides
+        run: |
+          grep -A100 "implementationguides" validation-service-fhir-r4/hapi.application.yaml
+
       - name: Start Validation Service
         run: |
           cd validation-service-fhir-r4
@@ -86,6 +90,9 @@ jobs:
 
       #- name: Install FHIR packages via $install
       #  run: python3 validation/FHIRValidationAction/scripts/configure-packages.py
+      - name: Check HAPI package installation
+        run: |
+          docker logs fhir-server 2>&1 | grep -iE "package|hl7.fhir.r4.core|implementationguide|terminology" || true
 
       - name: Upload FHIR assets + Examples
         run: python3 validation/FHIRValidationAction/scripts/upload-assets.py


### PR DESCRIPTION
**Stack Trace for terminology.r4**
We now have another case of the HAPI Validator u[sing R5 terminology to validate R4 Questionnaire.](https://github.com/NHSDigital/NHSEngland-FHIR-Programme-Health-Risks-Calculation/actions/runs/31163310963)
Some lines code in **configure-packages-application-yaml.py** excludes R4 Core and Terminology.
I have added this steps to enable us trace stack that FHIR R4 core and terminology are properly installed in the Docker image.